### PR TITLE
TEST: simplify verify job IDE caching (do not merge)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
     outputs:
       version: ${{ steps.properties.outputs.version }}
       changelog: ${{ steps.properties.outputs.changelog }}
-      pluginVerifierHomeDir: ${{ steps.properties.outputs.pluginVerifierHomeDir }}
     steps:
 
       # Free GitHub Actions Environment Disk Space
@@ -68,8 +67,7 @@ jobs:
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
-          
+
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -208,16 +206,11 @@ jobs:
         with:
           cache-read-only: true
 
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v6
-        with:
-          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
-
-      # Run Verify Plugin task and IntelliJ Plugin Verifier tool
+      # Run Verify Plugin task and IntelliJ Plugin Verifier tool.
+      # No separate IDE cache step: the IntelliJ Platform Gradle Plugin resolves verifier IDEs as
+      # regular Gradle dependencies under GRADLE_USER_HOME, which setup-gradle already caches.
       - name: Run Plugin Verification tasks
-        run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+        run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result


### PR DESCRIPTION
Testing whether removing the manual `actions/cache` step for Plugin Verifier IDEs still works now that intellij-platform-gradle-plugin resolves verifier IDEs as regular Gradle dependencies. For validation only — closing without merging once confirmed.