### PR TITLE
Fix total parse failure when a file lacks a trailing terminator

### DIFF
--- a/src/main/gen/com/github/dweindl/intellijAntimony/parser/AntimonyParser.java
+++ b/src/main/gen/com/github/dweindl/intellijAntimony/parser/AntimonyParser.java
@@ -442,7 +442,7 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // MODEL annotation_type string (SEMI | EOL)
+  // MODEL annotation_type string (SEMI | EOL | <<eof>>)
   public static boolean current_model_annotation(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "current_model_annotation")) return false;
     if (!nextTokenIs(builder_, MODEL)) return false;
@@ -456,12 +456,15 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
     return result_;
   }
 
-  // SEMI | EOL
+  // SEMI | EOL | <<eof>>
   private static boolean current_model_annotation_3(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "current_model_annotation_3")) return false;
     boolean result_;
+    Marker marker_ = enter_section_(builder_);
     result_ = consumeToken(builder_, SEMI);
     if (!result_) result_ = consumeToken(builder_, EOL);
+    if (!result_) result_ = eof(builder_, level_ + 1);
+    exit_section_(builder_, marker_, null, result_);
     return result_;
   }
 
@@ -749,7 +752,7 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // "import" filename (SEMI | EOL)
+  // "import" filename (SEMI | EOL | <<eof>>)
   public static boolean file_import(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "file_import")) return false;
     if (!nextTokenIs(builder_, IMPORT)) return false;
@@ -762,12 +765,15 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
     return result_;
   }
 
-  // SEMI | EOL
+  // SEMI | EOL | <<eof>>
   private static boolean file_import_2(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "file_import_2")) return false;
     boolean result_;
+    Marker marker_ = enter_section_(builder_);
     result_ = consumeToken(builder_, SEMI);
     if (!result_) result_ = consumeToken(builder_, EOL);
+    if (!result_) result_ = eof(builder_, level_ + 1);
+    exit_section_(builder_, marker_, null, result_);
     return result_;
   }
 
@@ -1096,7 +1102,7 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // model_id annotation_type string (SEMI | EOL)
+  // model_id annotation_type string (SEMI | EOL | <<eof>>)
   public static boolean model_annotation(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "model_annotation")) return false;
     if (!nextTokenIs(builder_, ID)) return false;
@@ -1110,12 +1116,15 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
     return result_;
   }
 
-  // SEMI | EOL
+  // SEMI | EOL | <<eof>>
   private static boolean model_annotation_3(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "model_annotation_3")) return false;
     boolean result_;
+    Marker marker_ = enter_section_(builder_);
     result_ = consumeToken(builder_, SEMI);
     if (!result_) result_ = consumeToken(builder_, EOL);
+    if (!result_) result_ = eof(builder_, level_ + 1);
+    exit_section_(builder_, marker_, null, result_);
     return result_;
   }
 
@@ -1132,7 +1141,7 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
   }
 
   /* ********************************************************** */
-  // (model_id ":")? model_id ("(" function_signature_arguments? ")")? ("," "timeconv" "=" expr)? ("," "extentconv" "=" expr)? (SEMI | EOL)
+  // (model_id ":")? model_id ("(" function_signature_arguments? ")")? ("," "timeconv" "=" expr)? ("," "extentconv" "=" expr)? (SEMI | EOL | <<eof>>)
   public static boolean model_import(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "model_import")) return false;
     if (!nextTokenIs(builder_, ID)) return false;
@@ -1228,12 +1237,15 @@ public class AntimonyParser implements PsiParser, LightPsiParser {
     return result_;
   }
 
-  // SEMI | EOL
+  // SEMI | EOL | <<eof>>
   private static boolean model_import_5(PsiBuilder builder_, int level_) {
     if (!recursion_guard_(builder_, level_, "model_import_5")) return false;
     boolean result_;
+    Marker marker_ = enter_section_(builder_);
     result_ = consumeToken(builder_, SEMI);
     if (!result_) result_ = consumeToken(builder_, EOL);
+    if (!result_) result_ = eof(builder_, level_ + 1);
+    exit_section_(builder_, marker_, null, result_);
     return result_;
   }
 

--- a/src/main/java/com/github/dweindl/intellijAntimony/Antimony.bnf
+++ b/src/main/java/com/github/dweindl/intellijAntimony/Antimony.bnf
@@ -205,17 +205,17 @@ event_assignments ::= event_assignment ("," (BACKSLASH EOL)* event_assignment)*
 event_assignment ::= identifier EQ expr
 event_id ::= identifier
 
-model_annotation ::= model_id annotation_type string (SEMI | EOL)
+model_annotation ::= model_id annotation_type string (SEMI | EOL | <<eof>>)
 annotation_type ::= identifier "." identifier
 
-current_model_annotation ::= MODEL annotation_type string (SEMI | EOL)
+current_model_annotation ::= MODEL annotation_type string (SEMI | EOL | <<eof>>)
 
 function_definition ::= "function" function_id "(" function_signature_arguments? ")" (SEMI | EOL) expr (SEMI | EOL) "end" {pin=1}
 function_signature_arguments ::= function_signature_argument ("," function_signature_argument)*
 function_signature_argument ::= identifier
 
-model_import ::= (model_id ":")? model_id ("(" function_signature_arguments? ")")? ("," "timeconv" "=" expr)? ("," "extentconv" "=" expr)? (SEMI | EOL)
-file_import ::= "import" filename (SEMI | EOL)
+model_import ::= (model_id ":")? model_id ("(" function_signature_arguments? ")")? ("," "timeconv" "=" expr)? ("," "extentconv" "=" expr)? (SEMI | EOL | <<eof>>)
+file_import ::= "import" filename (SEMI | EOL | <<eof>>)
 filename ::= string
 
 // TODO predefined units

--- a/src/test/java/com/github/dweindl/intellijAntimony/AntimonyParsingTest.java
+++ b/src/test/java/com/github/dweindl/intellijAntimony/AntimonyParsingTest.java
@@ -1,0 +1,35 @@
+package com.github.dweindl.intellijAntimony;
+
+import com.github.dweindl.intellijAntimony.psi.AntimonyFile;
+import com.github.dweindl.intellijAntimony.psi.AntimonyIdentifier;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.intellij.testFramework.ParsingTestCase;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.io.IOException;
+import java.util.List;
+
+import static com.github.dweindl.intellijAntimony.AntimonyUtil.findIdentifiers;
+
+public class AntimonyParsingTest extends BasePlatformTestCase {
+
+    public void testParsingAntimonyFile() throws IOException {
+        String testDataDir = "src/test/testData";
+        String fileName = "test2.ant";
+
+        String antimonyCode = ParsingTestCase.loadFileDefault(testDataDir, fileName);
+
+        PsiFile file = PsiFileFactory.getInstance(getProject()).createFileFromText(fileName, AntimonyFileType.INSTANCE, antimonyCode);
+        assertTrue(file instanceof AntimonyFile);
+
+        List<AntimonyIdentifier> ids = findIdentifiers((AntimonyFile) file, "not there");
+        assertEquals(0, ids.size());
+
+        ids = findIdentifiers((AntimonyFile) file, "k1");
+        assertEquals(2, ids.size());
+
+        ids = findIdentifiers((AntimonyFile) file, "S1");
+        assertEquals(3, ids.size());
+    }
+}


### PR DESCRIPTION
## Summary
- `model_annotation`, `current_model_annotation`, `model_import`, and `file_import` required `SEMI | EOL` but not `<<eof>>` as a terminator, unlike `reaction` which already accounts for this (`SEMI | EOL | <<eof>>`).
- Since these rules aren't `pin`ned, when the *last* statement in a file has no trailing newline, the terminator fails to match and the whole rule match is rolled back — not just that statement. That failure propagates to the top-level `antimonyFile` rule (which requires reaching true EOF), causing a **total rollback of the entire file's parse**. The fallback behavior then renders the whole document as a flat, untyped token list — no PSI structure at all, meaning no correct highlighting, references, rename, or completion context anywhere in the file.
- Net effect: any Antimony file missing a trailing newline on its last statement failed to parse *at all*, previously undetected since there were no parser-level tests.
- Adds `AntimonyParsingTest`, the first parser-level unit test in this project — it's what surfaced the bug.

## Test plan
- [x] `./gradlew test` passes (`AntimonyParsingTest` verifies `test2.ant`, which has no trailing newline, now parses with proper PSI structure and correct identifier lookup)
- [x] `./gradlew check` passes
- [x] Regenerated `src/main/gen` via the `generateLexer`/`generateParser` tasks added in #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)