### PR TITLE
Retry flaky Test job and capture stack traces on failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,8 +126,17 @@ jobs:
           cache-read-only: true
 
       # Run tests
+      # Retries on failure: instrumentCode/instrumentTestCode intermittently fail on cold-cache
+      # CI runs with a bare "1 >= 1" error (no useful stack trace without --stacktrace), tracing
+      # back to a shared Ant ClassLoader race in intellij-platform-gradle-plugin's
+      # InstrumentCodeTask / the IDE-bundled instrumenter - not something in this repo's control.
+      # See: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2068
       - name: Run Tests
-        run: ./gradlew check
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 2
+          command: ./gradlew check --stacktrace
 
       # Collect Tests Result of failed tests
       - name: Collect Tests Result


### PR DESCRIPTION
## Summary
- `instrumentCode`/`instrumentTestCode` intermittently fail on cold-cache CI runs with a bare `1 >= 1` error (seen on #94, #97, #98). Root cause: these two tasks deliberately share a single Ant `ClassLoader`/`Project` reference in `intellij-platform-gradle-plugin`'s `InstrumentCodeTask`, which delegates to the IDE-bundled instrumenter (`com.intellij.ant.InstrumentIdeaExtensions`) - a race there, not anything in this repo's code. Related upstream issue: https://github.com/JetBrains/intellij-platform-gradle-plugin/issues/2068
- Wraps the `Run Tests` step in `nick-fields/retry@v3` (2 attempts) so this doesn't require a manual rerun every time it flakes.
- Adds `--stacktrace` so if/when it recurs, the log has an actual stack trace instead of just `> 1 >= 1`, making it possible to report upstream with real evidence.

## Test plan
- [x] YAML validated
- [x] CI run on this PR exercises the new step (first attempt should just pass normally, proving the wrapper doesn't break the working case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)